### PR TITLE
ci: add pre-commit, molecule, github workflows + chore

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,5 @@
+---
+warn_list:
+  - experimental
+exclude_paths:
+  - .github/workflows/

--- a/.codespellignore
+++ b/.codespellignore
@@ -1,0 +1,1 @@
+browseable

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+---
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/default-bare.yml
+++ b/.github/workflows/default-bare.yml
@@ -1,0 +1,106 @@
+---
+name: default-bare
+
+on:
+  push:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  build:
+    permissions:
+      contents: read
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        os: [ubuntu-22.04, ubuntu-20.04]
+    env:
+      ANSIBLE_CALLBACKS_ENABLED: profile_tasks
+      ANSIBLE_EXTRA_VARS: ""
+      ANSIBLE_ROLE: theidiotyouyellat.opencanary
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: ${{ env.ANSIBLE_ROLE }}
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          pip3 install ansible-lint flake8 yamllint
+          which ansible
+          pip3 install ansible
+          pip3 show ansible
+          ls -l $HOME/.local/bin || true
+          ansible --version
+          cd $GITHUB_WORKSPACE/$ANSIBLE_ROLE
+          [ -f molecule/default/requirements.yml ] && ansible-galaxy install -r molecule/default/requirements.yml
+          { echo '[defaults]'; echo 'callback_whitelist = profile_tasks, timer'; echo 'roles_path = ../:/home/runner/.ansible/roles'; echo 'ansible_python_interpreter: /usr/bin/python3'; } >> ansible.cfg
+      - name: Environment
+        run: |
+          set -x
+          pwd
+          env
+          find . -ls
+      - name: run test
+        run: |
+          cd $GITHUB_WORKSPACE/$ANSIBLE_ROLE && ansible-playbook -i localhost, --connection=local --become -vvv molecule/default/converge.yml ${ANSIBLE_EXTRA_VARS}
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+      - name: idempotency run
+        run: |
+          cd $GITHUB_WORKSPACE/$ANSIBLE_ROLE && ansible-playbook -i localhost, --connection=local --become -vvv molecule/default/converge.yml ${ANSIBLE_EXTRA_VARS} | tee /tmp/idempotency.log | grep -q 'changed=0.*failed=0'  && (echo 'Idempotence test: pass' && exit 0)  || (echo 'Idempotence test: fail' && cat /tmp/idempotency.log && exit 0)
+      - name: On failure
+        run: |
+          systemctl -l --no-pager status
+          systemctl -l --no-pager --failed
+          ls -l /usr/bin/ | egrep '(python|pip|ansible)'
+          pip freeze
+          pip3 freeze
+          ip addr
+          cat /etc/resolv.conf
+          host www.google.com
+          ping -c 1 www.google.com || true
+          ping -c 1 8.8.8.8 || true
+        if: ${{ failure() }}
+        continue-on-error: true
+      - name: After script - ansible setup
+        run: |
+          ansible -i inventory --connection=local -m setup localhost
+        if: ${{ always() }}
+        continue-on-error: true
+      - name: After script - systemd
+        run: |
+          systemctl -l --no-pager status opencanaryd || true
+          systemd-analyze --no-pager security || true
+          systemd-analyze --no-pager security opencanaryd || true
+          systemd-analyze --no-pager verify opencanaryd || true
+          rsyslogd -v
+        if: ${{ always() }}
+        continue-on-error: true
+      - name: After script - etc
+        run: |
+          set -x
+          cat /etc/opencanaryd/opencanary.conf
+          cat /etc/systemd/system/opencanaryd.service
+        if: ${{ always() }}
+        continue-on-error: true
+      - name: After script - python
+        run: |
+          set -x
+          pip install pipdeptree
+          pipdeptree -r
+          pip freeze
+          pip3 freeze
+          /opt/opencanary/bin/pip install pipdeptree
+          /opt/opencanary/bin/pipdeptree -r
+          /opt/opencanary/bin/pip freeze
+        if: ${{ always() }}
+        continue-on-error: true

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         include:
           - molecule_distro: 'rockylinux:9'
-            experimental: false
+            experimental: true
           - molecule_distro: 'rockylinux:8'
             experimental: true
           - molecule_distro: 'ubuntu:22.04'

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install molecule[docker] ansible-lint flake8 testinfra ansible
+          pip install molecule molecule-plugins docker ansible-lint flake8 testinfra ansible
           mkdir -p $HOME/.ansible/roles && ln -s $GITHUB_WORKSPACE/$ANSIBLE_ROLE $HOME/.ansible/roles/
       - name: Environment
         run: |

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -1,0 +1,60 @@
+---
+name: AnsibleCI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  build:
+
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        include:
+          - molecule_distro: 'rockylinux:9'
+            experimental: false
+          - molecule_distro: 'rockylinux:8'
+            experimental: true
+          - molecule_distro: 'ubuntu:22.04'
+            experimental: false
+          - molecule_distro: 'ubuntu:20.04'
+            experimental: false
+    env:
+      ANSIBLE_CALLBACKS_ENABLED: profile_tasks
+      MOLECULE_NO_LOG: "false"
+      ANSIBLE_ROLE: theidiotyouyellat.opencanary
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: ${{ env.ANSIBLE_ROLE }}
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install molecule[docker] ansible-lint flake8 testinfra ansible
+          mkdir -p $HOME/.ansible/roles && ln -s $GITHUB_WORKSPACE/$ANSIBLE_ROLE $HOME/.ansible/roles/
+      - name: Environment
+        run: |
+          pwd
+          env
+          find -ls
+      - name: run test
+        run: |
+          cd $GITHUB_WORKSPACE/$ANSIBLE_ROLE && molecule test
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          MOLECULE_DISTRO: ${{ matrix.molecule_distro }}

--- a/.github/workflows/galaxy.yml
+++ b/.github/workflows/galaxy.yml
@@ -1,0 +1,26 @@
+---
+name: Ansible Galaxy release
+
+on:
+  release:
+    types: [created, edited, published, released]
+  push:
+    tags:
+      - '*'
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          path: theidiotyouyellat.opencanary
+      - name: galaxy
+        uses: robertdebock/galaxy-action@1.2.1
+        with:
+          galaxy_api_key: ${{ secrets.galaxy_api_key }}
+          path: theidiotyouyellat.opencanary
+          git_branch: master

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,61 @@
+---
+name: lint
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+    env:
+      ANSIBLE_CALLBACKS_ENABLED: profile_tasks
+      ANSIBLE_EXTRA_VARS: ""
+      ANSIBLE_ROLE: theidiotyouyellat.opencanary
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: ${{ env.ANSIBLE_ROLE }}
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          pip3 install --pre ansible-lint flake8 yamllint
+          which ansible
+          pip3 install ansible
+          pip3 show ansible
+          ls -l $HOME/.local/bin || true
+          ansible --version
+          cd $GITHUB_WORKSPACE/$ANSIBLE_ROLE
+          [ -f molecule/default/requirements.yml ] && ansible-galaxy install -r molecule/default/requirements.yml
+          { echo '[defaults]'; echo 'callbacks_enabled = profile_tasks, timer'; echo 'roles_path = ../:/home/runner/.ansible/roles'; echo 'ansible_python_interpreter: /usr/bin/python3'; } >> ansible.cfg
+      - name: Environment
+        run: |
+          pwd
+          env
+          find . -ls
+      - uses: codespell-project/actions-codespell@master
+        with:
+          ignore_words_file: ${{ env.ANSIBLE_ROLE }}/.codespellignore
+          skip: .git
+          path: ${{ env.ANSIBLE_ROLE }}
+        if: ${{ always() }}
+      - name: yamllint
+        run: |
+          cd $GITHUB_WORKSPACE/$ANSIBLE_ROLE && yamllint .
+        if: ${{ always() }}
+      - name: ansible-lint
+        run: |
+          cd $GITHUB_WORKSPACE/$ANSIBLE_ROLE && ansible-lint
+        if: ${{ always() }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+---
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-added-large-files
+      - id: check-json
+      - id: detect-private-key
+      - id: check-case-conflict
+      - id: requirements-txt-fixer
+      - id: check-ast
+      - id: check-shebang-scripts-are-executable
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-toml
+      - id: check-xml
+      # - id: detect-aws-credentials
+      - id: check-docstring-first
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.5
+    hooks:
+      - id: codespell
+        args: [-I, .codespellignore]
+  - repo: https://github.com/ansible-community/ansible-lint.git
+    rev: v6.18.0
+    hooks:
+      - id: ansible-lint
+        files: \.(yaml|yml)$

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,28 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  truthy: disable

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -91,3 +91,5 @@ samba_netbios_name: "{{ ansible_hostname }}"
 samba_share: personal
 samba_comment: "Personal docs"
 samba_path: "/opt/{{ samba_share }}"
+
+is_container: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,8 +8,8 @@ github_src_dir: "/opt/opencanary_src"
 
 # opencanary conf file defaults
 device_node_id: "opencanary-{{ ansible_hostname }}"
-ip_ignorelist: [ ]
-logtype_ignorelist: [ ]
+ip_ignorelist: []
+logtype_ignorelist: []
 git_enabled: "false"
 git_port: "9418"
 ftp_enabled: "false"
@@ -32,7 +32,7 @@ logger_syslog_port: 514
 webhook_method: "POST"
 webhook_data: '{"message": "%(message)s"}'
 webhook_status_code: 200
-webhook_ignore: [ ]
+webhook_ignore: []
 smtp_port: 25
 smtp_subject: "OpenCanary Alert"
 portscan_enabled: "false"
@@ -41,7 +41,7 @@ portscan_logfile: "/var/log/kern.log"
 portscan_synrate: "5"
 portscan_nmaposrate: "5"
 portscan_lorate: "3"
-portscan_ignore_ports: [ ]
+portscan_ignore_ports: []
 smb_auditfile: "/var/log/samba-audit.log"
 smb_enabled: "false"
 mysql_enabled: "false"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,14 +1,21 @@
+---
+
 - name: Start opencanaryd
-  systemd:
+  ansible.builtin.systemd:
     name: opencanaryd
     state: restarted
 
 - name: Stop opencanaryd
-  systemd:
+  ansible.builtin.systemd:
     name: opencanaryd
     state: stopped
 
 - name: Restart rsyslog
-  systemd:
+  ansible.builtin.systemd:
     name: rsyslogd
+    state: restarted
+
+- name: Restart opencanaryd
+  ansible.builtin.service:
+    name: opencanaryd
     state: restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,18 +4,22 @@
   ansible.builtin.systemd:
     name: opencanaryd
     state: restarted
+  when: not is_container | bool
 
 - name: Stop opencanaryd
   ansible.builtin.systemd:
     name: opencanaryd
     state: stopped
+  when: not is_container | bool
 
 - name: Restart rsyslog
   ansible.builtin.systemd:
     name: rsyslogd
     state: restarted
+  when: not is_container | bool
 
 - name: Restart opencanaryd
   ansible.builtin.service:
     name: opencanaryd
     state: restarted
+  when: not is_container | bool

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,3 +1,4 @@
+---
 galaxy_info:
   role_name: opencanary
   author: theidiotyouyellat

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,12 +3,12 @@ galaxy_info:
   author: theidiotyouyellat
   description: Configures an OpenCanary honeypot
   license: MIT
-  min_ansible_version: 2.7.0
+  min_ansible_version: '2.7.0'
   platforms:
     - name: EL
       versions:
-        - 8
-        - 9
+        - '8'
+        - '9'
     - name: Ubuntu
       versions:
         - bionic

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -31,4 +31,5 @@
       ansible.builtin.debug:
         var: ansible_virtualization_type
   roles:
+    - { role: juju4.redhat_epel, when: ansible_os_family == "RedHat" and ansible_distribution != "Fedora"}
     - theidiotyouyellat.opencanary

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -31,5 +31,4 @@
       ansible.builtin.debug:
         var: ansible_virtualization_type
   roles:
-    - { role: juju4.redhat_epel, when: ansible_os_family == "RedHat" and ansible_distribution != "Fedora"}
     - theidiotyouyellat.opencanary

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,34 @@
+---
+
+- name: Converge
+  hosts: all
+  environment:
+    http_proxy: "{{ lookup('env', 'http_proxy') }}"
+    https_proxy: "{{ lookup('env', 'https_proxy') }}"
+    no_proxy: "{{ lookup('env', 'no_proxy') }}"
+  remote_user: root
+  pre_tasks:
+    - name: Ubuntu | Install python3
+      ansible.builtin.raw: test -e /usr/bin/python3 || (apt -y update && apt install -y python3-minimal)
+      register: python3
+      changed_when: "'installed' in python3.stdout"
+      when: (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int >= 16)
+    - name: RedHat | Install python3
+      ansible.builtin.raw: test -e /usr/bin/python3 || (yum install -y python3)
+      register: python3
+      changed_when: "'installed' in python3.stdout"
+      when: (ansible_os_family == "RedHat" and ansible_distribution_major_version | int >= 8)
+    - name: Gather Facts
+      ansible.builtin.setup:
+      when: (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int >= 16)
+    - name: Ubuntu Bionic+, Redhat 8+ | Enforce python3 for ansible
+      ansible.builtin.set_fact:
+        ansible_python_interpreter: /usr/bin/python3
+      when: >
+        (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int >= 16) or
+        (ansible_os_family == "RedHat" and ansible_distribution_major_version | int >= 8)
+    - name: Debug | var ansible_virtualization_type
+      ansible.builtin.debug:
+        var: ansible_virtualization_type
+  roles:
+    - theidiotyouyellat.opencanary

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,34 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: ${MOLECULE_DISTRO:-ubuntu:20.04}
+    # env:
+    #   http_proxy: ${http_proxy}
+    #   https_proxy: ${https_proxy}
+    #   no_proxy: ${no_proxy}
+    groups:
+      - opencanarygroup
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      verbosity: 2
+scenario:
+  name: default
+  test_sequence:
+    - dependency
+    # - lint
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+verifier:
+  name: ansible

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,0 +1,4 @@
+---
+
+collections:
+  - name: ansible.posix

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -2,3 +2,6 @@
 
 collections:
   - name: ansible.posix
+
+roles:
+  - name: juju4.redhat_epel

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -2,6 +2,3 @@
 
 collections:
   - name: ansible.posix
-
-roles:
-  - name: juju4.redhat_epel

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -4,6 +4,7 @@
   hosts: opencanarygroup
   gather_facts: true
   vars:
+    smb_enabled: false
     pkg_test: samba
     opencanary_install_dir: "/opt/opencanary"
     bin: "{{ opencanary_install_dir }}/bin/opencanaryd"
@@ -38,6 +39,7 @@
     - name: Validate that needed packages are present
       ansible.builtin.assert:
         that: ansible_facts.packages[pkg_test]
+      when: smb_enabled | bool
 
     - name: Check executable
       ansible.builtin.stat:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -102,7 +102,7 @@
       ansible.builtin.pip:
         name: pip-audit
         state: present
-      become: yes
+      become: true
     - name: Pip list
       ansible.builtin.command: pip list
       changed_when: false
@@ -111,7 +111,7 @@
       ansible.builtin.pip:
         name: pipdeptree
         state: present
-      become: yes
+      become: true
     - name: Pipdeptree
       ansible.builtin.command: pipdeptree -r
       changed_when: false

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,126 @@
+---
+
+- name: Verify
+  hosts: opencanarygroup
+  gather_facts: true
+  vars:
+    pkg_test: samba
+    opencanary_install_dir: "/opt/opencanary"
+    bin: "{{ opencanary_install_dir }}/bin/opencanaryd"
+    config: "/etc/opencanaryd/opencanary.conf"
+    ports:
+      # canary
+      - { h: localhost, p: 9418 }
+      - { h: localhost, p: 21 }
+      - { h: localhost, p: 80 }
+    is_container: false
+  pre_tasks:
+    - name: Debug | var ansible_virtualization_type
+      ansible.builtin.debug:
+        var: ansible_virtualization_type
+    - name: Set fact is_container
+      ansible.builtin.set_fact:
+        is_container: true
+      when: >
+        (ansible_virtualization_type is defined and
+          (ansible_virtualization_type == "docker" or ansible_virtualization_type == "containerd"
+           or ansible_virtualization_type == "container"
+          )
+        )
+    - name: RedHat | Set fact
+      ansible.builtin.set_fact:
+        pkg_test: python3-devel
+      when: ansible_os_family == 'RedHat'
+  tasks:
+    - name: Gather package facts
+      ansible.builtin.package_facts:
+        manager: auto
+    - name: Validate that needed packages are present
+      ansible.builtin.assert:
+        that: ansible_facts.packages[pkg_test]
+
+    - name: Check executable
+      ansible.builtin.stat:
+        path: "{{ bin }}"
+      register: bin1
+    - name: Validate executable is present
+      ansible.builtin.assert:
+        that: bin1.stat.exists and bin1.stat.size != 0 and bin1.stat.mode == '0755'
+
+    - name: Check config file
+      ansible.builtin.stat:
+        path: "{{ config }}"
+      register: cfg1
+    - name: Validate configuration files are present
+      ansible.builtin.assert:
+        that: cfg1.stat.exists and cfg1.stat.size != 0
+
+    - name: Ensure opencanaryd running
+      ansible.builtin.command: pgrep -u root opencanaryd
+      register: ps3
+      changed_when: false
+      failed_when: false
+    - name: Validate ps output
+      ansible.builtin.assert:
+        that: ps3.stdout
+      when:
+        - not is_container|bool
+
+    - name: Ensure procps package is present
+      ansible.builtin.package:
+        name: procps
+        state: present
+      when: ansible_os_family == "RedHat"
+    - name: Check all processes
+      ansible.builtin.command: ps aux
+      changed_when: false
+      register: psa
+    - name: Debug | ps aux output
+      ansible.builtin.debug:
+        var: psa
+        verbosity: 1
+
+    - name: Ensure ports are listening
+      ansible.builtin.wait_for:
+        host: "{{ item.h }}"
+        port: "{{ item.p }}"
+        timeout: 10
+      with_items: "{{ ports }}"
+      when:
+        - not is_container|bool
+
+    - name: Pip outdated
+      ansible.builtin.command: pip list --outdated --path /usr/local/
+      changed_when: false
+      register: outdated
+    - name: Validate no outdated python pip
+      ansible.builtin.assert:
+        that:
+          - "'Package' not in outdated.stdout"
+
+    - name: Ensure pip-audit is present
+      ansible.builtin.pip:
+        name: pip-audit
+        state: present
+      become: yes
+    - name: Pip list
+      ansible.builtin.command: pip list
+      changed_when: false
+      failed_when: false
+    - name: Ensure pipdeptree is present
+      ansible.builtin.pip:
+        name: pipdeptree
+        state: present
+      become: yes
+    - name: Pipdeptree
+      ansible.builtin.command: pipdeptree -r
+      changed_when: false
+      failed_when: false
+    - name: Pip-audit
+      ansible.builtin.command: pip-audit --path /usr/local
+      changed_when: false
+      register: audit
+    - name: Validate no known vulnerabilities from pip-audit
+      ansible.builtin.assert:
+        that:
+          - "'No known vulnerabilities found' in audit.stderr"

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -1,36 +1,36 @@
 ---
-- block:
-  - name: Install dependencies - APT
-    apt:
-      name: "{{ apt_packages }}"
-      state: latest
-      update_cache: yes
-
-  - name: Install Samaba
-    apt:
-      name: samba
-      state: latest
-    when: smb_enabled == "true"
+- name: Debian
   when: ansible_facts['os_family'] == "Debian"
+  block:
+    - name: Install dependencies - APT
+      ansible.builtin.apt:
+        name: "{{ apt_packages }}"
+        state: present
+        update_cache: true
 
-- block:
-  - name: Install dependencies - DNF
-    dnf:
-      name: "{{ dnf_packages }}"
-      state: latest
-      update_cache: yes
-    when: ansible_facts['distribution_major_version'] == "8"
+    - name: Install Samba
+      ansible.builtin.apt:
+        name: samba
+        state: present
+      when: smb_enabled == "true"
 
-  - name: Install dependencies
-    dnf:
-      name: "{{ dnf_9_packages }}"
-      state: latest
-      update_cache: yes
-    when: ansible_facts['distribution_major_version'] == "9"
-
-  - name: Install Samaba
-    dnf:
-      name: samba
-      state: latest
-    when: smb_enabled == "true"
+- name: RedHat
   when: ansible_facts['os_family'] == "RedHat"
+  block:
+    - name: Install dependencies - DNF
+      ansible.builtin.dnf:
+        name: "{{ dnf_packages }}"
+        state: present
+      when: ansible_facts['distribution_major_version'] == "8"
+
+    - name: Install dependencies
+      ansible.builtin.dnf:
+        name: "{{ dnf_9_packages }}"
+        state: present
+      when: ansible_facts['distribution_major_version'] == "9"
+
+    - name: Install Samba
+      ansible.builtin.dnf:
+        name: samba
+        state: present
+      when: smb_enabled == "true"

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -21,16 +21,19 @@
       ansible.builtin.dnf:
         name: "{{ dnf_packages }}"
         state: present
+        update_cache: true
       when: ansible_facts['distribution_major_version'] == "8"
 
     - name: Install dependencies
       ansible.builtin.dnf:
         name: "{{ dnf_9_packages }}"
         state: present
+        update_cache: true
       when: ansible_facts['distribution_major_version'] == "9"
 
     - name: Install Samba
       ansible.builtin.dnf:
         name: samba
         state: present
+        update_cache: true
       when: smb_enabled == "true"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,16 @@
 ---
+
+- name: Set fact is_container
+  ansible.builtin.set_fact:
+    is_container: true
+  when: >
+    (ansible_virtualization_type is defined and
+      (ansible_virtualization_type == "docker"
+       or ansible_virtualization_type == "containerd"
+       or ansible_virtualization_type == "container"
+      )
+    )
+
 - name: Include dependencies
   ansible.builtin.include_tasks: dependencies.yml
   tags: [install]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
-- include_tasks: dependencies.yml
-  tags: [ install ]
+- name: Include dependencies
+  ansible.builtin.include_tasks: dependencies.yml
+  tags: [install]
 
-- include_tasks: opencanary.yml
-  tags: [ install, update ]
+- name: Include opencanary
+  ansible.builtin.include_tasks: opencanary.yml
+  tags: [install, update]

--- a/tasks/opencanary.yml
+++ b/tasks/opencanary.yml
@@ -113,3 +113,4 @@
     masked: false
     daemon_reload: true
   notify: Start opencanaryd
+  when: not is_container | bool

--- a/tasks/opencanary.yml
+++ b/tasks/opencanary.yml
@@ -32,6 +32,15 @@
         virtualenv: "{{ opencanary_install_dir }}"
         virtualenv_command: "/usr/bin/python3 -m venv"
 
+    - name: RedHat8 | Upgrade pip setuptools
+      ansible.builtin.pip:
+        name: setuptools
+        extra_args: --upgrade
+        virtualenv: "{{ opencanary_install_dir }}"
+        virtualenv_command: "/usr/bin/python3 -m venv"
+      when:
+        - (ansible_os_family == 'RedHat' and ansible_distribution_major_version|int == 8)
+
 - name: Install opencanary
   ansible.builtin.pip:
     name: opencanary

--- a/tasks/opencanary.yml
+++ b/tasks/opencanary.yml
@@ -1,36 +1,39 @@
 ---
 
-- block:
+- name: Github source install
+  when: install_source == "github"
+  block:
     - name: Create download directory
-      file:
+      ansible.builtin.file:
         path: "{{ github_src_dir }}"
         state: directory
         mode: '0755'
 
     - name: Clone GitHub repo
-      git:
+      ansible.builtin.git:
         repo: https://github.com/thinkst/opencanary.git
         dest: "{{ github_src_dir }}"
         version: "{{ opencanary_version }}"
 
     - name: Build Git Release
-      shell: 'python3 {{ github_src_dir }}/setup.py sdist'
+      ansible.builtin.command:  # noqa no-changed-when
+        cmd: 'python3 {{ github_src_dir }}/setup.py sdist'
       args:
         chdir: '{{ github_src_dir }}'
 
     - name: Get opencanary_tar location
-      shell: 'ls {{ github_src_dir }}/dist'
+      ansible.builtin.command: 'ls {{ github_src_dir }}/dist'
       register: opencanary_tar_name
+      changed_when: false
 
     - name: Install opencanary git
-      pip:
+      ansible.builtin.pip:
         name: 'file://{{ github_src_dir }}/dist/{{ opencanary_tar_name.stdout }}'
         virtualenv: "{{ opencanary_install_dir }}"
         virtualenv_command: "/usr/bin/python3 -m venv"
-  when: install_source == "github"
 
 - name: Install opencanary
-  pip:
+  ansible.builtin.pip:
     name: opencanary
     virtualenv: "{{ opencanary_install_dir }}"
     virtualenv_command: "/usr/bin/python3 -m venv"
@@ -38,7 +41,7 @@
   when: install_source == "pypi"
 
 - name: Install optional python dependencies
-  pip:
+  ansible.builtin.pip:
     name:
       - scapy
       - pcapy-ng
@@ -47,60 +50,66 @@
   when: snmp_enabled == "true"
 
 - name: Create /etc/opencanary
-  file:
+  ansible.builtin.file:
     path: /etc/opencanaryd
     state: directory
+    mode: '0755'
 
 - name: Install opencanaryd.service
-  template:
+  ansible.builtin.template:
     src: opencanaryd_service.jn2
     dest: /etc/systemd/system/opencanaryd.service
+    mode: '0644'
 
 - name: Install opencanary config
-  template:
+  ansible.builtin.template:
     src: opencanary_conf.jn2
     dest: /etc/opencanaryd/opencanary.conf
+    mode: '0644'
   register: config
+  notify:
+    - Restart opencanaryd
 
-- block:
-  - name: Get python venv version
-    command: 'ls "{{ opencanary_install_dir }}/lib"'
-    register: dir
-
-  - name: HTTP/HTTPS custom skin copy
-    copy:
-      src: "{{ http_customskin_folder }}"
-      dest: "{{ opencanary_install_dir }}/lib/{{ dir.stdout }}/site-packages/opencanary/modules/data/http/skin/"
+- name: HTTP custom skin enabled
   when: http_customskin_folder is defined
+  block:
+    - name: Get python venv version
+      ansible.builtin.command: 'ls "{{ opencanary_install_dir }}/lib"'
+      register: dir
+      changed_when: false
 
-- block:
+    - name: HTTP/HTTPS custom skin copy
+      ansible.builtin.copy:
+        src: "{{ http_customskin_folder }}"
+        dest: "{{ opencanary_install_dir }}/lib/{{ dir.stdout }}/site-packages/opencanary/modules/data/http/skin/"
+        mode: '0755'
+
+- name: Samba enabled
+  when: smb_enabled == "true"
+  block:
     - name: Create {{ samba_path }}
-      file:
+      ansible.builtin.file:
         path: "{{ samba_path }}"
         state: directory
         mode: "0777"
 
     - name: Configure Samba
-      template:
+      ansible.builtin.template:
         src: samba_conf.jn2
         dest: /etc/samba/smb.conf
+        mode: '0644'
 
     - name: Configure Samba Audit
-      template:
+      ansible.builtin.template:
         src: samba_audit.jn2
         dest: /etc/rsyslog.d/smb_audit.conf
+        mode: '0644'
       notify: Restart rsyslogd
-  when: smb_enabled == "true"
 
 - name: Enable opencanaryd.service
-  systemd:
+  ansible.builtin.systemd:
     name: opencanaryd
-    enabled: yes
-    masked: no
-    daemon_reload: yes
+    enabled: true
+    masked: false
+    daemon_reload: true
   notify: Start opencanaryd
-
-- name: Restart opencanaryd
-  command: echo restart opencanaryd
-  notify: Start opencanaryd
-  when: config.changed

--- a/tasks/opencanary.yml
+++ b/tasks/opencanary.yml
@@ -32,14 +32,14 @@
         virtualenv: "{{ opencanary_install_dir }}"
         virtualenv_command: "/usr/bin/python3 -m venv"
 
-    - name: RedHat8 | Upgrade pip setuptools
-      ansible.builtin.pip:
-        name: setuptools
-        extra_args: --upgrade
-        virtualenv: "{{ opencanary_install_dir }}"
-        virtualenv_command: "/usr/bin/python3 -m venv"
-      when:
-        - (ansible_os_family == 'RedHat' and ansible_distribution_major_version|int == 8)
+- name: RedHat8 | Upgrade pip setuptools
+  ansible.builtin.pip:
+    name: setuptools
+    extra_args: --upgrade
+    virtualenv: "{{ opencanary_install_dir }}"
+    virtualenv_command: "/usr/bin/python3 -m venv"
+  when:
+    - (ansible_os_family == 'RedHat' and ansible_distribution_major_version|int == 8)
 
 - name: Install opencanary
   ansible.builtin.pip:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,7 +4,7 @@ apt_packages:
   - python3-dev
   - python3-pip
   - python3-venv
-  #- python3-scapy
+  # - python3-scapy
   - libssl-dev
   - libffi-dev
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,6 +7,7 @@ apt_packages:
   # - python3-scapy
   - libssl-dev
   - libffi-dev
+  - systemd
 
 dnf_packages:
   - git
@@ -17,6 +18,7 @@ dnf_packages:
   - openssl-devel
   - libpcap
   - libffi-devel
+  - systemd
 
 dnf_9_packages:
   - git
@@ -26,3 +28,4 @@ dnf_9_packages:
   - openssl-devel
   - libpcap-devel
   - libffi-devel
+  - systemd


### PR DESCRIPTION
## Proposed changes

This implements continuous integration through
* pre-commit: mostly client-side
* molecule pipeline (default + github action) through docker
* default-bare github action directly on image to test without docker+systemd limitations

This also includes chore to fix lint issues (ansible-lint, yamllint mostly).
Redhat platform is marked experimental as failing inside molecule docker and can't be tested bare in github workflows.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Lint and unit tests pass locally with my changes (if applicable) - with this PR
- [x] I have run pre-commit (`pre-commit` in the repo) - added with PR too
- [x] I have added tests that prove my fix is effective or that my feature works - object of the PR
- [ ] I have added necessary documentation (if appropriate) - no but feel free to suggest where this should go
- [ ] Linked to the relevant github issue or github discussion - issues or discussions not opened in repo
