### PR TITLE
Added /usr/sbin to service template

### DIFF
--- a/templates/opencanaryd_service.jn2
+++ b/templates/opencanaryd_service.jn2
@@ -6,7 +6,7 @@ After=network.target
 [Service]
 Restart=always
 Environment=VIRTUAL_ENV={{ opencanary_install_dir }}
-Environment=PATH=$VIRTUAL_ENV/bin:/usr/bin:$PATH
+Environment=PATH=$VIRTUAL_ENV/bin:/usr/bin:/usr/sbin:$PATH
 WorkingDirectory={{ opencanary_install_dir }}/bin
 ExecStart={{ opencanary_install_dir }}/bin/opencanaryd --dev
 


### PR DESCRIPTION
Fixes an issue with portscan not detecting iptables on Ubuntu 22.04 

## Proposed changes

Add /usr/sbin to path in systemd service template to allow the virtualenv to find iptables.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Lint and unit tests pass locally with my changes (if applicable)
- [ ] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion
